### PR TITLE
fix: Fix Cpp standard detection for MSVC

### DIFF
--- a/lockfree/mpmc/priority_queue.hpp
+++ b/lockfree/mpmc/priority_queue.hpp
@@ -47,7 +47,7 @@
 #include <cstddef>
 #include <type_traits>
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #include <optional>
 #endif
 
@@ -80,7 +80,7 @@ template <typename T, size_t size, size_t priority_count> class PriorityQueue {
      */
     bool Pop(T &element);
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
     /**
      * @brief Removes an element with the highest priority from the queue.
      * Should only be called from the consumer thread.

--- a/lockfree/mpmc/priority_queue_impl.hpp
+++ b/lockfree/mpmc/priority_queue_impl.hpp
@@ -67,7 +67,7 @@ bool PriorityQueue<T, size, priority_count>::Pop(T &element) {
 }
 
 /********************* std::optional API **********************/
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 template <typename T, size_t size, size_t priority_count>
 std::optional<T> PriorityQueue<T, size, priority_count>::PopOptional() {
     T element;

--- a/lockfree/mpmc/queue.hpp
+++ b/lockfree/mpmc/queue.hpp
@@ -47,7 +47,7 @@
 #include <cstddef>
 #include <type_traits>
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #include <optional>
 #endif
 
@@ -77,7 +77,7 @@ template <typename T, size_t size> class Queue {
      */
     bool Pop(T &element);
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
     /**
      * @brief Removes an element from the queue.
      * @retval Either the element or nothing

--- a/lockfree/mpmc/queue_impl.hpp
+++ b/lockfree/mpmc/queue_impl.hpp
@@ -111,7 +111,7 @@ template <typename T, size_t size> bool Queue<T, size>::Pop(T &element) {
 }
 
 /********************* std::optional API **********************/
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 template <typename T, size_t size>
 std::optional<T> Queue<T, size>::PopOptional() {
     T element;

--- a/lockfree/spsc/bipartite_buf.hpp
+++ b/lockfree/spsc/bipartite_buf.hpp
@@ -48,7 +48,7 @@
 #include <cstddef>
 #include <type_traits>
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
 #include <span>
 #endif
 
@@ -72,7 +72,7 @@ template <typename T, size_t size> class BipartiteBuf {
      */
     T *WriteAcquire(const size_t free_required);
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     /**
      * @brief Acquires a linear region in the bipartite buffer for writing
      * Should only be called from the producer thread.
@@ -90,7 +90,7 @@ template <typename T, size_t size> class BipartiteBuf {
      */
     void WriteRelease(const size_t written);
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     /**
      * @brief Releases the bipartite buffer after a write
      * Should only be called from the producer thread.
@@ -108,7 +108,7 @@ template <typename T, size_t size> class BipartiteBuf {
      */
     std::pair<T *, size_t> ReadAcquire();
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     /**
      * @brief Acquires a linear region in the bipartite buffer for reading
      * Should only be called from the consumer thread.
@@ -125,7 +125,7 @@ template <typename T, size_t size> class BipartiteBuf {
      */
     void ReadRelease(const size_t read);
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     /**
      * @brief Releases the bipartite buffer after a read
      * Should only be called from the consumer thread.

--- a/lockfree/spsc/bipartite_buf_impl.hpp
+++ b/lockfree/spsc/bipartite_buf_impl.hpp
@@ -160,7 +160,7 @@ void BipartiteBuf<T, size>::ReadRelease(const size_t read) {
 }
 
 /********************** std::span API *************************/
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
 template <typename T, size_t size>
 std::span<T>
 BipartiteBuf<T, size>::WriteAcquireSpan(const size_t free_required) {

--- a/lockfree/spsc/priority_queue.hpp
+++ b/lockfree/spsc/priority_queue.hpp
@@ -48,7 +48,7 @@
 #include <cstddef>
 #include <type_traits>
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #include <optional>
 #endif
 
@@ -81,7 +81,7 @@ template <typename T, size_t size, size_t priority_count> class PriorityQueue {
      */
     bool Pop(T &element);
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
     /**
      * @brief Removes an element with the highest priority from the queue.
      * Should only be called from the consumer thread.

--- a/lockfree/spsc/priority_queue_impl.hpp
+++ b/lockfree/spsc/priority_queue_impl.hpp
@@ -68,7 +68,7 @@ bool PriorityQueue<T, size, priority_count>::Pop(T &element) {
 }
 
 /********************* std::optional API **********************/
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 template <typename T, size_t size, size_t priority_count>
 std::optional<T> PriorityQueue<T, size, priority_count>::PopOptional() {
     T element;

--- a/lockfree/spsc/queue.hpp
+++ b/lockfree/spsc/queue.hpp
@@ -48,7 +48,7 @@
 #include <cstddef>
 #include <type_traits>
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #include <optional>
 #endif
 
@@ -80,7 +80,7 @@ template <typename T, size_t size> class Queue {
      */
     bool Pop(T &element);
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
     /**
      * @brief Removes an element from the queue.
      * Should only be called from the consumer thread.

--- a/lockfree/spsc/queue_impl.hpp
+++ b/lockfree/spsc/queue_impl.hpp
@@ -94,7 +94,7 @@ template <typename T, size_t size> bool Queue<T, size>::Pop(T &element) {
 }
 
 /********************* std::optional API **********************/
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 template <typename T, size_t size>
 std::optional<T> Queue<T, size>::PopOptional() {
     T element;

--- a/lockfree/spsc/ring_buf.hpp
+++ b/lockfree/spsc/ring_buf.hpp
@@ -49,7 +49,7 @@
 #include <cstddef>
 #include <type_traits>
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
 #include <span>
 #endif
 
@@ -82,7 +82,7 @@ template <typename T, size_t size> class RingBuf {
      */
     template <size_t arr_size> bool Write(const std::array<T, arr_size> &data);
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     /**
      * @brief Writes data to the ring buffer.
      * Should only be called from the producer thread.
@@ -109,7 +109,7 @@ template <typename T, size_t size> class RingBuf {
      */
     template <size_t arr_size> bool Read(std::array<T, arr_size> &data);
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     /**
      * @brief Reads data from the ring buffer.
      * Should only be called from the consumer thread.
@@ -151,7 +151,7 @@ template <typename T, size_t size> class RingBuf {
      * @param[out] Span to read to
      * @retval Write success
      */
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     bool Peek(std::span<T> data) const;
 #endif
 

--- a/lockfree/spsc/ring_buf_impl.hpp
+++ b/lockfree/spsc/ring_buf_impl.hpp
@@ -201,7 +201,7 @@ bool RingBuf<T, size>::Peek(std::array<T, arr_size> &data) const {
 }
 
 /********************** std::span API *************************/
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
 template <typename T, size_t size>
 bool RingBuf<T, size>::Write(std::span<const T> data) {
     return Write(data.data(), data.size());


### PR DESCRIPTION
Since __cplusplus is hard defined to 199711L without using /Zc:__cplusplus, switch to using _MSVC_LANG when MSVC is used to detect the cpp version.

Solves https://github.com/DNedic/lockfree/issues/5