### PR TITLE
Do not include stdlib headers inside namespace

### DIFF
--- a/lockfree/mpmc/priority_queue.hpp
+++ b/lockfree/mpmc/priority_queue.hpp
@@ -96,10 +96,10 @@ template <typename T, size_t size, size_t priority_count> class PriorityQueue {
 
 /************************** INCLUDE ***************************/
 
-/* Include the implementation */
-#include "priority_queue_impl.hpp"
-
 } /* namespace mpmc */
 } /* namespace lockfree */
+
+/* Include the implementation */
+#include "priority_queue_impl.hpp"
 
 #endif /* LOCKFREE_MPMC_PRIORITY_QUEUE_HPP */

--- a/lockfree/mpmc/priority_queue_impl.hpp
+++ b/lockfree/mpmc/priority_queue_impl.hpp
@@ -45,6 +45,9 @@
 
 /********************** PUBLIC METHODS ************************/
 
+namespace lockfree {
+namespace mpmc {
+
 template <typename T, size_t size, size_t priority_count>
 bool PriorityQueue<T, size, priority_count>::Push(const T &element,
                                                   const size_t priority) {
@@ -80,3 +83,6 @@ std::optional<T> PriorityQueue<T, size, priority_count>::PopOptional() {
     }
 }
 #endif
+
+} /* namespace mpmc */
+} /* namespace lockfree */

--- a/lockfree/mpmc/queue.hpp
+++ b/lockfree/mpmc/queue.hpp
@@ -111,10 +111,10 @@ template <typename T, size_t size> class Queue {
 
 /************************** INCLUDE ***************************/
 
-/* Include the implementation */
-#include "queue_impl.hpp"
-
 } /* namespace mpmc */
 } /* namespace lockfree */
+
+/* Include the implementation */
+#include "queue_impl.hpp"
 
 #endif /* LOCKFREE_MPMC_QUEUE_HPP */

--- a/lockfree/mpmc/queue_impl.hpp
+++ b/lockfree/mpmc/queue_impl.hpp
@@ -41,6 +41,9 @@
 
 /********************** PUBLIC METHODS ************************/
 
+namespace lockfree {
+namespace mpmc {
+
 template <typename T, size_t size>
 Queue<T, size>::Queue() : _r_count(0U), _w_count(0U) {}
 
@@ -124,3 +127,6 @@ std::optional<T> Queue<T, size>::PopOptional() {
     }
 }
 #endif
+
+} /* namespace mpmc */
+} /* namespace lockfree */

--- a/lockfree/spsc/bipartite_buf.hpp
+++ b/lockfree/spsc/bipartite_buf.hpp
@@ -157,12 +157,14 @@ template <typename T, size_t size> class BipartiteBuf {
     bool _read_wrapped;  /**< Read wrapped flag, used only in the consumer */
 };
 
+} /* namespace spsc */
+} /* namespace lockfree */
+
 /************************** INCLUDE ***************************/
 
 /* Include the implementation */
 #include "bipartite_buf_impl.hpp"
 
-} /* namespace spsc */
-} /* namespace lockfree */
+
 
 #endif /* LOCKFREE_BIPARTITE_BUF_HPP */

--- a/lockfree/spsc/bipartite_buf_impl.hpp
+++ b/lockfree/spsc/bipartite_buf_impl.hpp
@@ -47,6 +47,9 @@
 
 /********************** PUBLIC METHODS ************************/
 
+namespace lockfree {
+namespace spsc {
+
 template <typename T, size_t size>
 BipartiteBuf<T, size>::BipartiteBuf()
     : _r(0U), _w(0U), _i(0U), _write_wrapped(false), _read_wrapped(false) {}
@@ -199,3 +202,6 @@ size_t BipartiteBuf<T, size>::CalcFree(const size_t w, const size_t r) {
         return (size - (w - r)) - 1U;
     }
 }
+
+} /* namespace spsc */
+} /* namespace lockfree */

--- a/lockfree/spsc/priority_queue.hpp
+++ b/lockfree/spsc/priority_queue.hpp
@@ -97,10 +97,10 @@ template <typename T, size_t size, size_t priority_count> class PriorityQueue {
 
 /************************** INCLUDE ***************************/
 
-/* Include the implementation */
-#include "priority_queue_impl.hpp"
-
 } /* namespace spsc */
 } /* namespace lockfree */
+
+/* Include the implementation */
+#include "priority_queue_impl.hpp"
 
 #endif /* LOCKFREE_PRIORITY_QUEUE_HPP */

--- a/lockfree/spsc/priority_queue_impl.hpp
+++ b/lockfree/spsc/priority_queue_impl.hpp
@@ -46,6 +46,9 @@
 
 /********************** PUBLIC METHODS ************************/
 
+namespace lockfree {
+namespace spsc {
+
 template <typename T, size_t size, size_t priority_count>
 bool PriorityQueue<T, size, priority_count>::Push(const T &element,
                                                   const size_t priority) {
@@ -81,3 +84,6 @@ std::optional<T> PriorityQueue<T, size, priority_count>::PopOptional() {
     }
 }
 #endif
+
+} /* namespace spsc */
+} /* namespace lockfree */

--- a/lockfree/spsc/queue.hpp
+++ b/lockfree/spsc/queue.hpp
@@ -104,10 +104,10 @@ template <typename T, size_t size> class Queue {
 
 /************************** INCLUDE ***************************/
 
-/* Include the implementation */
-#include "queue_impl.hpp"
-
 } /* namespace spsc */
 } /* namespace lockfree */
+
+/* Include the implementation */
+#include "queue_impl.hpp"
 
 #endif /* LOCKFREE_QUEUE_HPP */

--- a/lockfree/spsc/queue_impl.hpp
+++ b/lockfree/spsc/queue_impl.hpp
@@ -42,6 +42,9 @@
 
 /********************** PUBLIC METHODS ************************/
 
+namespace lockfree {
+namespace spsc {
+
 template <typename T, size_t size> Queue<T, size>::Queue() : _r(0U), _w(0U) {}
 
 template <typename T, size_t size> bool Queue<T, size>::Push(const T &element) {
@@ -107,3 +110,6 @@ std::optional<T> Queue<T, size>::PopOptional() {
     }
 }
 #endif
+
+} /* namespace spsc */
+} /* namespace lockfree */

--- a/lockfree/spsc/ring_buf.hpp
+++ b/lockfree/spsc/ring_buf.hpp
@@ -200,10 +200,10 @@ template <typename T, size_t size> class RingBuf {
 
 /************************** INCLUDE ***************************/
 
-/* Include the implementation */
-#include "ring_buf_impl.hpp"
-
 } /* namespace spsc */
 } /* namespace lockfree */
+
+/* Include the implementation */
+#include "ring_buf_impl.hpp"
 
 #endif /* LOCKFREE_RING_BUF_HPP */

--- a/lockfree/spsc/ring_buf_impl.hpp
+++ b/lockfree/spsc/ring_buf_impl.hpp
@@ -42,6 +42,9 @@
 
 /********************** PUBLIC METHODS ************************/
 
+namespace lockfree {
+namespace spsc {
+
 template <typename T, size_t size>
 RingBuf<T, size>::RingBuf() : _r(0U), _w(0U) {}
 
@@ -237,3 +240,6 @@ size_t RingBuf<T, size>::CalcAvailable(const size_t w, const size_t r) {
         return size - (r - w);
     }
 }
+
+} /* namespace spsc */
+} /* namespace lockfree */


### PR DESCRIPTION
This causes the compiler to crash on arm gcc 12.2.  
Tests with native gcc are working tough