### PR TITLE
tests: Add sanitizers to tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,21 @@ add_executable(tests
 # Required in order to test the std::span API as well
 target_compile_features(tests PRIVATE cxx_std_20)
 
+target_compile_options(tests
+PRIVATE
+    -fno-omit-frame-pointer # For nicer stack traces with sanitizers
+    -fsanitize=address
+    -fsanitize=signed-integer-overflow
+    -fsanitize=bounds
+)
+
+target_link_options(tests
+PRIVATE
+    -fsanitize=address
+    -fsanitize=signed-integer-overflow
+    -fsanitize=bounds
+)
+
 target_link_libraries(tests
 PRIVATE
     ${PROJECT_NAME}

--- a/tests/spsc/ring_buf.cpp
+++ b/tests/spsc/ring_buf.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Get free after a wrapping write", "[rb_get_free_wrapped]") {
     rb.Skip(sizeof(test_data) / sizeof(test_data[0]));
 
     const float test_data2[900] = {3.1416F};
-    rb.Write(test_data, sizeof(test_data2) / sizeof(test_data2[0]));
+    rb.Write(test_data2, sizeof(test_data2) / sizeof(test_data2[0]));
 
     /* After a wrapping write */
     REQUIRE(rb.GetFree() ==
@@ -78,8 +78,8 @@ TEST_CASE("Get available after a wrapping write",
 
     rb.Skip(sizeof(test_data) / sizeof(test_data[0]));
 
-    const float test_data2[900] = {3.1416F};
-    rb.Write(test_data, sizeof(test_data2) / sizeof(test_data2[0]));
+    const double test_data2[900] = {3.1416F};
+    rb.Write(test_data2, sizeof(test_data2) / sizeof(test_data2[0]));
 
     /* After a wrapping write */
     REQUIRE(rb.GetAvailable() == sizeof(test_data2) / sizeof(test_data2[0]));


### PR DESCRIPTION
This should help detect bugs in the implementation by enabling sanitizers for the tests only.