### PR TITLE
fix(RingBuffer): Add missing include needed for memcpy

### DIFF
--- a/lockfree/spsc/ring_buf_impl.hpp
+++ b/lockfree/spsc/ring_buf_impl.hpp
@@ -37,6 +37,8 @@
  * Version:         v2.0.9
  **************************************************************/
 
+#include <cstring>
+
 namespace lockfree {
 namespace spsc {
 /********************** PUBLIC METHODS ************************/


### PR DESCRIPTION
It looks like the required `cstring` include was missing in the RingBuffer implementation, leading to [errors when building](https://github.com/DNedic/lockfree/issues/24), this fixes that.